### PR TITLE
[semver:minor] Plug-in pnacl build on Linux

### DIFF
--- a/src/jobs/linux-build.yml
+++ b/src/jobs/linux-build.yml
@@ -91,5 +91,13 @@ steps:
       profile: "emscripten"
       type: "Debug"
       build-missing: << parameters.build-missing >>
+  - build:
+      profile: "chrome"
+      type: "Release"
+      build-missing: << parameters.build-missing >>
+  - build:
+      profile: "chrome"
+      type: "Debug"
+      build-missing: << parameters.build-missing >>
   - upload:
       package-name: << parameters.package-name >>


### PR DESCRIPTION
This adds the chrome build to the linux setup -- I think we only need to build the packages on Linux, as they should be usable on mac/windows as well (at least the mac package sum is same as the linux one).