### PR TITLE
[semver:patch] Re-run 'conan user' prior to upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
  - Current development changes [ to be moved to release ]
 
+## [1.0.2] - 2021-04-15
+### Added
+ - Rerun ‘conan user’ prior to uploads to avoid timeouts
 
 ## [1.0.1] - 2021-04-06
 ### Added

--- a/src/commands/upload.yml
+++ b/src/commands/upload.yml
@@ -13,4 +13,5 @@ steps:
       command: |
         channel=${CIRCLE_BRANCH//[_+=.,\/]/-}
         echo "Uploading to " ${channel}
+        conan user gitlab+deploy-token-296862 -p $GITLAB_API_KEY -r vst-libs
         conan upload -c -r vst-libs --force --all "<< parameters.package-name >>/*@vernierst+vst-libs/${channel}"


### PR DESCRIPTION
On long running builds the credentials set up at the start of the build can
expire before we get to upload, and the build then hangs waiting for creds
entered on a prompt.