### PR TITLE
[semver: patch] explicitely 'set -e' in the build script

### DIFF
--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -22,6 +22,7 @@ steps:
   - run:
       name: Build << parameters.profile >>  << parameters.type >>
       command: |
+        set -e
         deps=${CIRCLE_BRANCH##*@}
         if [ "$deps" = "${CIRCLE_BRANCH}" ]; then
           deps=""


### PR DESCRIPTION
This is necessary for builds to fail correctly on windows.